### PR TITLE
chore: bump analytical-platform-github-actions to v7.1.0

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -13,4 +13,4 @@ jobs:
     name: Container Scan
     permissions:
       contents: read
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-scan.yml@6238a30dc9be3f1c5b76b665d9a09f9e163183f7 # 6.2.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-scan.yml@8465086d84a8ae8fb993ef582f00cf13b8ceb9c8 # v7.1.0

--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -13,6 +13,6 @@ jobs:
     name: Scheduled Container Scan
     permissions:
       contents: read
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-scheduled-container-scan.yml@6238a30dc9be3f1c5b76b665d9a09f9e163183f7 # 6.2.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-scheduled-container-scan.yml@8465086d84a8ae8fb993ef582f00cf13b8ceb9c8 # v7.1.0
     secrets:
       cve-scan-slack-webhook-url: ${{ secrets.ANALYTICAL_PLATFORM_CVE_SCAN_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Updates the following to pinned commit 8465086d84a8ae8fb993ef582f00cf13b8ceb9c8 (v7.1.0):

- ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-scheduled-container-scan.yml
- ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-scan.yml