### PR TITLE
Configure Grype + Patch

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,6 +11,7 @@
     "vscode": {
       "extensions": [
         "EditorConfig.EditorConfig",
+        "esbenp.prettier-vscode",
         "GitHub.vscode-github-actions",
         "GitHub.vscode-pull-request-github"
       ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,6 @@
     "vscode": {
       "extensions": [
         "EditorConfig.EditorConfig",
-        "esbenp.prettier-vscode",
         "GitHub.vscode-github-actions",
         "GitHub.vscode-pull-request-github"
       ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: ":dependabot: github-actions"
       include: "scope"
@@ -13,6 +15,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: ":dependabot: devcontainers"
       include: "scope"
@@ -20,6 +24,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: ":dependabot: docker"
       include: "scope"

--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -6,7 +6,7 @@ on:
     tags:
       - "*"
 
-permissions: {}
+permissions: { }
 
 jobs:
   container-release:
@@ -17,6 +17,6 @@ jobs:
       contents: write
       id-token: write
       packages: write
-     uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-release.yml@72f9c303ec3becced97e2d4472122fee783ff4a4 # v8.0.1
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-release.yml@72f9c303ec3becced97e2d4472122fee783ff4a4 # v8.0.1
     secrets:
       release-failure-webhook-url: ${{ secrets.ANALYTICAL_PLATFORM_RELEASE_FAILURE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -17,6 +17,6 @@ jobs:
       contents: write
       id-token: write
       packages: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-release.yml@6238a30dc9be3f1c5b76b665d9a09f9e163183f7 # 6.2.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-release.yml@72f9c303ec3becced97e2d4472122fee783ff4a4 # v8.0.1
     secrets:
       release-failure-webhook-url: ${{ secrets.ANALYTICAL_PLATFORM_RELEASE_FAILURE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -17,6 +17,6 @@ jobs:
       contents: write
       id-token: write
       packages: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-release.yml@72f9c303ec3becced97e2d4472122fee783ff4a4 # v8.0.1
+     uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-release.yml@72f9c303ec3becced97e2d4472122fee783ff4a4 # v8.0.1
     secrets:
       release-failure-webhook-url: ${{ secrets.ANALYTICAL_PLATFORM_RELEASE_FAILURE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -6,7 +6,7 @@ on:
     tags:
       - "*"
 
-permissions: { }
+permissions: {}
 
 jobs:
   container-release:

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -13,4 +13,6 @@ jobs:
     name: Container Scan
     permissions:
       contents: read
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-scan.yml@8465086d84a8ae8fb993ef582f00cf13b8ceb9c8 # v7.1.0
+      pull-requests: write
+      security-events: write
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-scan.yml@72f9c303ec3becced97e2d4472122fee783ff4a4 # v8.0.1

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
 
-permissions: { }
+permissions: {}
 
 jobs:
   container-scan:

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
 
-permissions: {}
+permissions: { }
 
 jobs:
   container-scan:

--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
 
-permissions: { }
+permissions: {}
 
 jobs:
   container-test:

--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -13,4 +13,4 @@ jobs:
     name: Container Test
     permissions:
       contents: read
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-test.yml@6238a30dc9be3f1c5b76b665d9a09f9e163183f7 # 6.2.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-test.yml@72f9c303ec3becced97e2d4472122fee783ff4a4 # v8.0.1

--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
 
-permissions: {}
+permissions: { }
 
 jobs:
   container-test:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
 
-permissions: { }
+permissions: {}
 
 jobs:
   dependency-review:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
 
-permissions: {}
+permissions: { }
 
 jobs:
   dependency-review:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,6 +22,6 @@ jobs:
           persist-credentials: false
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@05fe4576374b728f0c523d6a13d64c25081e0803 # v4.8.3
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: critical

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -8,7 +8,7 @@ on:
   schedule:
     - cron: "30 6 * * 1"
 
-permissions: {}
+permissions: { }
 
 jobs:
   openssf-scorecard:

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -8,7 +8,7 @@ on:
   schedule:
     - cron: "30 6 * * 1"
 
-permissions: { }
+permissions: {}
 
 jobs:
   openssf-scorecard:

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -17,4 +17,4 @@ jobs:
       contents: read
       id-token: write
       security-events: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-openssf-scorecard.yml@6238a30dc9be3f1c5b76b665d9a09f9e163183f7 # 6.2.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-openssf-scorecard.yml@72f9c303ec3becced97e2d4472122fee783ff4a4 # v8.0.1

--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -13,6 +13,6 @@ jobs:
     name: Scheduled Container Scan
     permissions:
       contents: read
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-scheduled-container-scan.yml@8465086d84a8ae8fb993ef582f00cf13b8ceb9c8 # v7.1.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-scheduled-container-scan.yml@72f9c303ec3becced97e2d4472122fee783ff4a4 # v8.0.1
     secrets:
       cve-scan-slack-webhook-url: ${{ secrets.ANALYTICAL_PLATFORM_CVE_SCAN_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -6,7 +6,7 @@ on:
     - cron: "0 9 * * 1-5" # Every weekday at 9AM UTC
   workflow_dispatch:
 
-permissions: { }
+permissions: {}
 
 jobs:
   scheduled-container-scan:

--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -6,7 +6,7 @@ on:
     - cron: "0 9 * * 1-5" # Every weekday at 9AM UTC
   workflow_dispatch:
 
-permissions: {}
+permissions: { }
 
 jobs:
   scheduled-container-scan:

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
 
-permissions: { }
+permissions: {}
 
 jobs:
   super-linter:

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
 
-permissions: {}
+permissions: { }
 
 jobs:
   super-linter:

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -15,4 +15,5 @@ jobs:
       contents: read
       packages: read
       statuses: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-super-linter.yml@72a6b41dd6f2ccce15aa70b0e42178f6f5583018 # 5.3.0
+      pull-requests: write
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-super-linter.yml@72f9c303ec3becced97e2d4472122fee783ff4a4 # v8.0.1

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - main
 
-permissions: { }
+permissions: {}
 
 jobs:
   zizmor:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - main
 
-permissions: {}
+permissions: { }
 
 jobs:
   zizmor:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,4 +18,4 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-zizmor.yml@6238a30dc9be3f1c5b76b665d9a09f9e163183f7 # 6.2.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-zizmor.yml@72f9c303ec3becced97e2d4472122fee783ff4a4 # v8.0.1

--- a/.grype.yml
+++ b/.grype.yml
@@ -4,20 +4,38 @@
 # upstream Ubuntu base image and are not directly patchable in this repository.
 
 ignore:
-  - vulnerability: GO-2026-4918-golang.org/x/net
-    reason: "Found in upstream /usr/bin/pebble in the pinned Ubuntu base image; no direct patch path in this repository."
+  - vulnerability: GO-2026-4918
+    package:
+      name: golang.org/x/net
+      location: /usr/bin/pebble
+    reason: "Upstream Pebble in pinned Ubuntu base image."
 
-  - vulnerability: GO-2026-5037-stdlib
-    reason: "Found in upstream /usr/bin/pebble in the pinned Ubuntu base image; no direct patch path in this repository."
+  - vulnerability: GO-2026-5037
+    package:
+      name: stdlib
+      location: /usr/bin/pebble
+    reason: "Upstream Pebble in pinned Ubuntu base image."
 
   - vulnerability: CVE-2026-27145
-    reason: "Found in upstream /usr/bin/pebble in the pinned Ubuntu base image; no direct patch path in this repository."
+    package:
+      name: stdlib
+      location: /usr/bin/pebble
+    reason: "Upstream Pebble in pinned Ubuntu base image."
 
   - vulnerability: CVE-2026-42504
-    reason: "Found in upstream /usr/bin/pebble in the pinned Ubuntu base image; no direct patch path in this repository."
+    package:
+      name: stdlib
+      location: /usr/bin/pebble
+    reason: "Upstream Pebble in pinned Ubuntu base image."
 
-  - vulnerability: GO-2026-5038-stdlib
-    reason: "Found in upstream /usr/bin/pebble in the pinned Ubuntu base image; no direct patch path in this repository."
+  - vulnerability: GO-2026-5038
+    package:
+      name: stdlib
+      location: /usr/bin/pebble
+    reason: "Upstream Pebble in pinned Ubuntu base image."
 
-  - vulnerability: GO-2026-5026-golang.org/x/net
-    reason: "Found in upstream /usr/bin/pebble in the pinned Ubuntu base image; no direct patch path in this repository."
+  - vulnerability: GO-2026-5026
+    package:
+      name: golang.org/x/net
+      location: /usr/bin/pebble
+    reason: "Upstream Pebble in pinned Ubuntu base image."

--- a/.grype.yml
+++ b/.grype.yml
@@ -1,0 +1,23 @@
+---
+# Grype configuration for container vulnerability scanning.
+# These vulnerabilities are reported from /usr/bin/pebble bundled in the
+# upstream Ubuntu base image and are not directly patchable in this repository.
+
+ignore:
+  - vulnerability: GO-2026-4918-golang.org/x/net
+    reason: "Found in upstream /usr/bin/pebble in the pinned Ubuntu base image; no direct patch path in this repository."
+
+  - vulnerability: GO-2026-5037-stdlib
+    reason: "Found in upstream /usr/bin/pebble in the pinned Ubuntu base image; no direct patch path in this repository."
+
+  - vulnerability: CVE-2026-27145
+    reason: "Found in upstream /usr/bin/pebble in the pinned Ubuntu base image; no direct patch path in this repository."
+
+  - vulnerability: CVE-2026-42504
+    reason: "Found in upstream /usr/bin/pebble in the pinned Ubuntu base image; no direct patch path in this repository."
+
+  - vulnerability: GO-2026-5038-stdlib
+    reason: "Found in upstream /usr/bin/pebble in the pinned Ubuntu base image; no direct patch path in this repository."
+
+  - vulnerability: GO-2026-5026-golang.org/x/net
+    reason: "Found in upstream /usr/bin/pebble in the pinned Ubuntu base image; no direct patch path in this repository."

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #checkov:skip=CKV_DOCKER_2: HEALTHCHECK not required - Health checks are implemented downstream of this image
 
-FROM public.ecr.aws/ubuntu/ubuntu:24.04@sha256:ef59d9e82939bbce08973bdffb8761b025f75369fb7d2882cdc4938b5a9e992e
+FROM public.ecr.aws/ubuntu/ubuntu:26.04@sha256:b5d8146c52b57381de84f4cbbf47c2f637e0f4017fe5a4a54f71251bde83fafa
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform (analytical-platform@digital.justice.gov.uk)" \
@@ -34,11 +34,11 @@ RUN <<EOF
 apt-get update --yes
 
 apt-get install --yes \
-  "curl=8.5.0-2ubuntu10.6" \
-  "gpgv=2.4.4-2ubuntu17.4" \
-  "iputils-ping=3:20240117-1ubuntu0.1" \
-  "netcat-openbsd=1.226-1ubuntu2" \
-  "traceroute=1:2.1.5-1"
+  "curl=8.18.0-1ubuntu2.2" \
+  "gpgv=2.4.8-4ubuntu3" \
+  "iputils-ping=3:20250605-1ubuntu1" \
+  "netcat-openbsd=1.234-1" \
+  "traceroute=1:2.1.6-1build1"
 
 apt-get clean --yes
 EOF

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ make run
 Dependabot is configured to do this in [`.github/dependabot.yml`](.github/dependabot.yml), but if you need to get the digest, do the following
 
 ```bash
-docker pull --platform linux/amd64 public.ecr.aws/ubuntu/ubuntu:24.04
+docker pull --platform linux/amd64 public.ecr.aws/ubuntu/ubuntu:26.04
 
-docker image inspect --format='{{ index .RepoDigests 0 }}' public.ecr.aws/ubuntu/ubuntu:24.04
+docker image inspect --format='{{ index .RepoDigests 0 }}' public.ecr.aws/ubuntu/ubuntu:26.04
 ```
 
 ### Base APT Packages

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -5,7 +5,7 @@ commandTests:
   - name: "ubuntu"
     command: "grep"
     args: ["DISTRIB_RELEASE", "/etc/lsb-release"]
-    expectedOutput: ["DISTRIB_RELEASE=24.04"]
+    expectedOutput: ["DISTRIB_RELEASE=26.04"]
 
   - name: "whoami"
     command: "whoami"


### PR DESCRIPTION
This pull request makes several important updates to the CI/CD workflows and the base Docker image. The main focus is on upgrading dependencies and workflows to their latest versions for improved security, compatibility, and feature support. The changes include bumping the base Ubuntu image version, updating package versions, and aligning GitHub Actions workflows with newer reusable workflow versions.

**Docker image updates:**

* Upgraded the base image in `Dockerfile` from Ubuntu 24.04 to 26.04, and updated installed package versions (`curl`, `gpgv`, `iputils-ping`, `netcat-openbsd`, `traceroute`) to match the new Ubuntu release. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L3-R3) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L37-R41)

**GitHub Actions workflow updates:**

* Updated all uses of `ministryofjustice/analytical-platform-github-actions` reusable workflows (container release, test, scan, scheduled scan, super-linter, openssf-scorecard, zizmor) to version `v8.0.1` for consistency and to leverage the latest improvements. [[1]](diffhunk://#diff-f7dba7ba2acdd5f1e3108e789cd859fbccdf6c3d145ce92b405e0614f4b3ea25L20-R20) [[2]](diffhunk://#diff-087befbeeffccfe44172951ff59b735182c50dd82b492d4f1e14791ab7d5bf93L16-R16) [[3]](diffhunk://#diff-82164c54d75d44ae01b6b66b7a35dbfd22168229f7376fcd6aef1f117ff176d8L16-R18) [[4]](diffhunk://#diff-459b22d426579c7680cc738374a478e42dbe5cbece91faebccee3304be8d9e25L16-R16) [[5]](diffhunk://#diff-9c84297a74a0feb6fda62b494c5bb8f653a3d78aac605920fd0c4057f947f482L18-R19) [[6]](diffhunk://#diff-2462706bed7e6e817d2961ac353dce113404d139fc511ed570f6890addbec9cbL20-R20) [[7]](diffhunk://#diff-8e6408444d2bf2bed6f02c5dc62a7f1f6ab7337eae098d332986e6a81411aeb7L21-R21)

* Added or adjusted workflow permissions in several workflows (e.g., `pull-requests: write`, `security-events: write`) to meet new requirements or best practices of the updated reusable workflows. [[1]](diffhunk://#diff-82164c54d75d44ae01b6b66b7a35dbfd22168229f7376fcd6aef1f117ff176d8L16-R18) [[2]](diffhunk://#diff-9c84297a74a0feb6fda62b494c5bb8f653a3d78aac605920fd0c4057f947f482L18-R19)

* Bumped `actions/dependency-review-action` from version `v4.8.3` to `v5.0.0` in `dependency-review.yml` to use the latest security checks.