### PR TITLE
Add artifact-metadata: write to release workflow

### DIFF
--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -13,6 +13,7 @@ jobs:
     name: Container Release
     permissions:
       actions: read
+      artifact-metadata: write
       attestations: write
       contents: write
       id-token: write


### PR DESCRIPTION
This pull request introduces a minor update to the workflow permissions in `.github/workflows/container-release.yml`, granting write access to artifact metadata.

* Updated the `permissions` section to include `artifact-metadata: write`, allowing the workflow to write artifact metadata.