### PR TITLE
changed schedule run from 9AM to 7AM and vuln fix

### DIFF
--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -3,7 +3,7 @@ name: ⏰ Scheduled Container Scan
 
 on:
   schedule:
-    - cron: "0 9 * * 1-5" # Every weekday at 9AM UTC
+    - cron: "0 7 * * 1-5" # Every weekday at 7AM UTC
   workflow_dispatch:
 
 permissions: {}
@@ -13,6 +13,6 @@ jobs:
     name: Scheduled Container Scan
     permissions:
       contents: read
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-scheduled-container-scan.yml@72f9c303ec3becced97e2d4472122fee783ff4a4 # v8.0.1
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-scheduled-container-scan.yml@aa8abd093cd24a89b8dd2d76b6733d8121c64c52 # v8.0.3
     secrets:
       cve-scan-slack-webhook-url: ${{ secrets.ANALYTICAL_PLATFORM_CVE_SCAN_SLACK_WEBHOOK_URL }}

--- a/.grype.yml
+++ b/.grype.yml
@@ -39,7 +39,7 @@ ignore:
       name: golang.org/x/net
       location: /usr/bin/pebble
     reason: "Upstream Pebble in pinned Ubuntu base image."
-    
+
   - vulnerability: CVE-2026-39822
     package:
       name: stdlib

--- a/.grype.yml
+++ b/.grype.yml
@@ -39,3 +39,15 @@ ignore:
       name: golang.org/x/net
       location: /usr/bin/pebble
     reason: "Upstream Pebble in pinned Ubuntu base image."
+    
+  - vulnerability: CVE-2026-39822
+    package:
+      name: stdlib
+      location: /usr/bin/pebble
+    reason: "Upstream Pebble in pinned Ubuntu base image."
+
+  - vulnerability: GO-2026-4970
+    package:
+      name: stdlib
+      location: /usr/bin/pebble
+    reason: "Upstream Pebble in pinned Ubuntu base image."

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ apt-get update --yes
 apt-get install --yes \
   "curl=8.18.0-1ubuntu2.3" \
   "gpgv=2.4.8-4ubuntu3" \
+  "gzip=1.14-1~exp2ubuntu1.1" \
   "iputils-ping=3:20250605-1ubuntu1" \
   "netcat-openbsd=1.234-1" \
   "traceroute=1:2.1.6-1build1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN <<EOF
 apt-get update --yes
 
 apt-get install --yes \
-  "curl=8.18.0-1ubuntu2.2" \
+  "curl=8.18.0-1ubuntu2.3" \
   "gpgv=2.4.8-4ubuntu3" \
   "iputils-ping=3:20250605-1ubuntu1" \
   "netcat-openbsd=1.234-1" \


### PR DESCRIPTION
Changed the schedule to run at `7 AM UTC` instead of `9 AM`, because we're using a shared runner, which doesn't guarantee the exact scheduled run time. This way, by the time our office hours start, we should already have the scan results. Additional changes
- added vuln ignore for `CVE-2026-39822` and `GO-2026-4970`
- pinned latest version of scheduled run actions
- `curl` version changed to `8.18.0-1ubuntu2.3`
- pinnged gzip [version](https://ubuntu.com/security/notices/USN-8512-1) `1.14-1~exp2ubuntu1.1`

PR is part of [this](https://github.com/ministryofjustice/data-platform/issues/529) ticket.