### PR TITLE
CVE Fix - Update base image digest to include libc security patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #checkov:skip=CKV_DOCKER_2: HEALTHCHECK not required - Health checks are implemented downstream of this image
 
-FROM public.ecr.aws/ubuntu/ubuntu:24.04@sha256:ef59d9e82939bbce08973bdffb8761b025f75369fb7d2882cdc4938b5a9e992e
+FROM public.ecr.aws/ubuntu/ubuntu:24.04@sha256:22a8228e1e48cbe7e0e0f2056e752ffb8a35950cda150a4e5e16417200bec648
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform (analytical-platform@digital.justice.gov.uk)" \


### PR DESCRIPTION
This pull request updates the base image used in the `Dockerfile` to a newer version. This change ensures the container uses the latest available security and stability improvements.

Base image update:

* Updated the `FROM` line in `Dockerfile` to use a newer Ubuntu 24.04 image by specifying a new SHA256 digest.