### PR TITLE
CVE Fix - Update base image digest to include libc security patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,9 @@ apt-get install --yes \
   "gpgv=2.4.8-4ubuntu3" \
   "gzip=1.14-1~exp2ubuntu1.1" \
   "iputils-ping=3:20250605-1ubuntu1" \
+  "libc-bin=2.43-2ubuntu2.3" \
+  "libc-gconv-modules-extra=2.43-2ubuntu2.3" \
+  "libc6=2.43-2ubuntu2.3" \
   "netcat-openbsd=1.234-1" \
   "traceroute=1:2.1.6-1build1"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #checkov:skip=CKV_DOCKER_2: HEALTHCHECK not required - Health checks are implemented downstream of this image
 
-FROM public.ecr.aws/ubuntu/ubuntu:26.04@sha256:0cef5a65b54ef16d70fb45fde28828e19df7c25c550952bfd42fb8040c276702
+FROM public.ecr.aws/ubuntu/ubuntu:26.04@sha256:a5da6f6b18c3a4b8dcc73244592f7096f417d2667966d0e33460e9e308f25f67
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform (analytical-platform@digital.justice.gov.uk)" \

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The [Renovate config](./.github/renovate.json) also disables organisation-level 
 If you need to manually get latest versions of the APT packages, they can be obtained by running the following
 
 ```bash
-docker run -it --rm --platform linux/amd64 public.ecr.aws/ubuntu/ubuntu:24.04
+docker run -it --rm --platform linux/amd64 public.ecr.aws/ubuntu/ubuntu:26.04
 
 apt-get update
 


### PR DESCRIPTION
This pull request updates the base image used in the `Dockerfile` to a newer version. This change ensures the container is built on a more recent and potentially more secure or stable foundation.

Base image update:

* Updated the `FROM` line in `Dockerfile` to use a newer `ubuntu:26.04` image with a new SHA256 digest.