### PR TITLE
build: update ubuntu base image digest and curl package version

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,5 +1,10 @@
 {
   "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:": {
+      "version": "4.0.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5",
+      "integrity": "sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5"
+    },
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "version": "2.14.0",
       "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:445e84b0c213225bfdae977a72b4125f65e38eadcd49616dae04f1af24aa122d",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:": {},
     "ghcr.io/devcontainers/features/github-cli:": {},
+    "ghcr.io/ministryofjustice/devcontainer-feature/apm:": {},
     "ghcr.io/ministryofjustice/devcontainer-feature/container-structure-test:1": {},
     "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis:1": {}
   },
@@ -15,5 +16,6 @@
         "GitHub.vscode-pull-request-github"
       ]
     }
-  }
+  },
+  "postCreateCommand": "/bin/bash .devcontainer/post-create.sh"
 }

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+sudo apt-get update
+sudo apt-get install --yes bubblewrap socat
+
+# Install agent package manager dependencies.
+apm install --frozen

--- a/.github/prompts/maintenance.prompt.md
+++ b/.github/prompts/maintenance.prompt.md
@@ -1,0 +1,87 @@
+---
+description: "Update the Ubuntu base image digest and pinned APT package versions in the Dockerfile as a single pull request"
+tools: ["search/codebase", "search", "edit/editFiles", "execute/runInTerminal", "execute/getTerminalOutput"]
+---
+
+# Maintenance
+
+Perform maintenance on the `Dockerfile`. Update the Ubuntu base image digest and the pinned APT package versions together, and deliver them as a single pull request.
+
+## Objective
+
+In one pull request:
+
+1. Update the pinned digest for `public.ecr.aws/ubuntu/ubuntu:24.04` to the latest published digest for `linux/amd64`.
+2. Refresh the pinned APT package versions to the latest available for Ubuntu 24.04, preserving the current package list.
+
+## Required Outcome
+
+1. Create a single maintenance branch.
+2. Update the Ubuntu base image digest in the `FROM` line.
+3. Update the pinned APT package versions.
+4. Prepare one PR-ready change summary covering both updates.
+
+## Execution Steps
+
+1. Create a maintenance branch.
+
+```bash
+git checkout -b chore/maintenance-dockerfile-<yyyymmdd>
+```
+
+2. Update the Ubuntu base image digest.
+
+- Pull the target image for `linux/amd64`.
+
+```bash
+docker pull --platform linux/amd64 public.ecr.aws/ubuntu/ubuntu:24.04
+```
+
+- Retrieve the current repo digest.
+
+```bash
+docker image inspect --format='{{ index .RepoDigests 0 }}' public.ecr.aws/ubuntu/ubuntu:24.04
+```
+
+- Extract the `sha256:...` value and update the `FROM` line in `Dockerfile`.
+
+3. Update the pinned APT package versions.
+
+- Start a temporary Ubuntu 24.04 container using the same base image.
+
+```bash
+docker run -it --rm --platform linux/amd64 public.ecr.aws/ubuntu/ubuntu:24.04
+```
+
+- In the container, check package candidates.
+
+```bash
+apt-get update
+apt-cache policy curl gpgv iputils-ping netcat-openbsd traceroute
+```
+
+- Update the pinned versions in `Dockerfile` for:
+
+  - `curl`
+  - `gpgv`
+  - `iputils-ping`
+  - `netcat-openbsd`
+  - `traceroute`
+
+4. Exit the container.
+
+5. Prepare a single PR summarising both updates:
+
+- Old digest and new digest (confirm tag remains `24.04`).
+- Package versions before and after.
+- Any package that could not be upgraded and why.
+
+Building and testing the image is handled by CI/CD, so it is not required as part of this runbook.
+
+## Guardrails
+
+- Keep the base image repository and tag unchanged (`public.ecr.aws/ubuntu/ubuntu:24.04`).
+- Keep platform assumption aligned to `linux/amd64`.
+- Do not add or remove packages unless explicitly requested.
+- Keep all package installs pinned to explicit versions.
+- Deliver both updates in the same branch and pull request.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #checkov:skip=CKV_DOCKER_2: HEALTHCHECK not required - Health checks are implemented downstream of this image
 
-FROM public.ecr.aws/ubuntu/ubuntu:24.04@sha256:ef59d9e82939bbce08973bdffb8761b025f75369fb7d2882cdc4938b5a9e992e
+FROM public.ecr.aws/ubuntu/ubuntu:24.04@sha256:22a8228e1e48cbe7e0e0f2056e752ffb8a35950cda150a4e5e16417200bec648
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform (analytical-platform@digital.justice.gov.uk)" \
@@ -34,7 +34,7 @@ RUN <<EOF
 apt-get update --yes
 
 apt-get install --yes \
-  "curl=8.5.0-2ubuntu10.6" \
+  "curl=8.5.0-2ubuntu10.11" \
   "gpgv=2.4.4-2ubuntu17.4" \
   "iputils-ping=3:20240117-1ubuntu0.1" \
   "netcat-openbsd=1.226-1ubuntu2" \

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ make run
 
 ## Managing Software Versions
 
+This repository includes a Copilot prompt for maintenance in [`.github/prompts/`](.github/prompts/). To run it, open Copilot Chat in VS Code and type `/maintenance`. The prompt updates the Ubuntu base image digest and the pinned APT package versions in the [Dockerfile](./Dockerfile) and prepares a single pull request.
+
 ### Ubuntu
 
 Dependabot is configured to do this in [`.github/dependabot.yml`](.github/dependabot.yml), but if you need to get the digest, do the following
@@ -42,15 +44,14 @@ docker image inspect --format='{{ index .RepoDigests 0 }}' public.ecr.aws/ubuntu
 
 ### Base APT Packages
 
-The latest versions of the APT packages are managed by [Renovate](https://docs.renovatebot.com/) via the [Renovate `deb` data source](https://docs.renovatebot.com/modules/datasource/deb/) which matches packages through `regex` (regular expression) matching the `# renovate` comments in the [Dockerfile](./Dockerfile).
-The [Renovate config](./.github/renovate.json) also disables organisation-level settings for Renovate, so it can compliment rather than conflict with Dependabot.
+The APT packages installed in the image are pinned to explicit versions in the [Dockerfile](./Dockerfile) and are updated manually. See the [`/maintenance`](.github/prompts/maintenance.prompt.md) prompt for the runbook.
 
-If you need to manually get latest versions of the APT packages, they can be obtained by running the following
+To get the latest available versions of the APT packages, run the following
 
 ```bash
 docker run -it --rm --platform linux/amd64 public.ecr.aws/ubuntu/ubuntu:24.04
 
 apt-get update
 
-apt-cache policy curl iputils-ping netcat-openbsd
+apt-cache policy curl gpgv iputils-ping netcat-openbsd traceroute
 ```

--- a/apm.yml
+++ b/apm.yml
@@ -1,0 +1,8 @@
+---
+version: 1.0.0
+name: analytical-platform-network-diagnostics
+targets:
+  - copilot
+dependencies:
+  apm:
+    - ministryofjustice/data-platform-ai-toolkit/toolkits/universal#main


### PR DESCRIPTION
## Summary

Updates the `Dockerfile` build dependencies.

### Ubuntu base image

- Digest: `sha256:ef59d9e82939bbce08973bdffb8761b025f75369fb7d2882cdc4938b5a9e992e` -> `sha256:22a8228e1e48cbe7e0e0f2056e752ffb8a35950cda150a4e5e16417200bec648` (tag remains `24.04`)

### APT packages

| Package | Before | After |
| --- | --- | --- |
| curl | `8.5.0-2ubuntu10.6` | `8.5.0-2ubuntu10.11` |

`gpgv`, `iputils-ping`, `netcat-openbsd`, and `traceroute` are already at their latest available versions.

Building and testing is handled by CI/CD.
