### PR TITLE
build: update ubuntu base image digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #checkov:skip=CKV_DOCKER_2: HEALTHCHECK not required - Health checks are implemented downstream of this image
 
-FROM public.ecr.aws/ubuntu/ubuntu:26.04@sha256:0cef5a65b54ef16d70fb45fde28828e19df7c25c550952bfd42fb8040c276702
+FROM public.ecr.aws/ubuntu/ubuntu:26.04@sha256:a5da6f6b18c3a4b8dcc73244592f7096f417d2667966d0e33460e9e308f25f67
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform (analytical-platform@digital.justice.gov.uk)" \


### PR DESCRIPTION
## Summary

Updates the `Dockerfile` build dependencies.

### Base image

- `public.ecr.aws/ubuntu/ubuntu:26.04` digest: `sha256:0cef5a65b54ef16d70fb45fde28828e19df7c25c550952bfd42fb8040c276702` -> `sha256:a5da6f6b18c3a4b8dcc73244592f7096f417d2667966d0e33460e9e308f25f67` (image and tag unchanged)

### APT packages

No changes. `curl`, `gpgv`, `gzip`, `iputils-ping`, `netcat-openbsd`, and `traceroute` are already at their latest available versions.

Building and testing is handled by CI/CD.
